### PR TITLE
added sendFile

### DIFF
--- a/src/express.ts
+++ b/src/express.ts
@@ -67,6 +67,7 @@ export type Action =
   | { type: 'setHeader'; name: string; value: string }
   | { type: 'clearCookie'; name: string; options: CookieOptions }
   | { type: 'setCookie'; name: string; value: string; options: CookieOptions }
+  | { type: 'setFile'; path: string }
 
 const endResponse: Action = { type: 'endResponse' }
 
@@ -168,6 +169,13 @@ export class ExpressConnection<S> implements Connection<S> {
   endResponse(): ExpressConnection<ResponseEnded> {
     return this.chain(endResponse, true)
   }
+
+  /**
+   * @since 0.7.0
+   */
+  setFile(path: string): ExpressConnection<ResponseEnded> {
+    return this.chain({ type: 'setFile', path })
+  }
 }
 
 function run(res: Response, action: Action): Response {
@@ -186,6 +194,9 @@ function run(res: Response, action: Action): Response {
       return res
     case 'setStatus':
       return res.status(action.status)
+    case 'setFile':
+      res.sendFile(action.path)
+      return res
   }
 }
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -93,6 +93,42 @@ describe('Middleware', () => {
     })
   })
 
+  describe('sendFile', () => {
+    it('should send the file', () => {
+      const filename = __filename
+      const m = H.sendFile(filename, () => 'will not happen')
+      const c = new MockConnection<H.BodyOpen>(new MockRequest())
+      return assertSuccess(m, c, undefined, [{ type: 'setFile', path: filename }])
+    })
+    it('should return result of error handler if filename is a directory', () => {
+      const product = 'error-handler'
+      const filename = __dirname
+      const c = new MockConnection<H.BodyOpen>(new MockRequest())
+      const m = H.sendFile(filename, () => product)
+      return assertFailure(m, c, err => {
+        assert.strictEqual(product, err)
+      })
+    })
+    it('should return result of error handler if file does not exist', () => {
+      const product = 'error-handler'
+      const filename = 'no-exist-file.xyz'
+      const c = new MockConnection<H.BodyOpen>(new MockRequest())
+      const m = H.sendFile(filename, () => product)
+      return assertFailure(m, c, err => {
+        assert.strictEqual(product, err)
+      })
+    })
+    it('should return result of error handler if filename is a relative path', () => {
+      const product = 'error-handler'
+      const filename = './relative/path'
+      const c = new MockConnection<H.BodyOpen>(new MockRequest())
+      const m = H.sendFile(filename, () => product)
+      return assertFailure(m, c, err => {
+        assert.strictEqual(product, err)
+      })
+    })
+  })
+
   describe('json', () => {
     it('should add the proper header and send the content', () => {
       const m = H.json({ a: 1 }, E.toError)


### PR DESCRIPTION
I wanted to be able to send files with hyper-ts but there was no way to use it natively. I had to write Express code and then use `fromRequestHandler` to turn it into a hyper-ts middleware.

One can use `sendFile` it in lieu of `send`. It will also transition the index from `BodyOpen` to `ResponseEnded`. It takes an error handler just like `json` does, and it will trigger the error handler if one of three things is true:

1. the path is a relative path (Express, for example, only allows absolute paths, so this is somewhat opinionated); I've also named the parameter in `sendFile` `absolutePath` to hint to an end user that the path must be absolute.
2. the path is to a file, not a directory
3. the file exists 

I updated the `ExpressConnection` to work with this as well and added some unit tests.