### PR TITLE
Add indexed functions

### DIFF
--- a/docs/modules/Middleware.ts.md
+++ b/docs/modules/Middleware.ts.md
@@ -26,11 +26,14 @@ Added in v0.7.0
   - [mapLeft](#mapleft)
 - [Functor](#functor)
   - [map](#map)
+- [IxFunctor](#ixfunctor)
+  - [imap](#imap)
+- [IxMonad](#ixmonad)
+  - [ichain](#ichain)
+  - [ichainW](#ichainw)
 - [Monad](#monad)
   - [chain](#chain)
   - [chainW](#chainw)
-  - [ichain](#ichain)
-  - [ichainW](#ichainw)
 - [Pointed](#pointed)
   - [iof](#iof)
   - [of](#of)
@@ -121,6 +124,11 @@ Added in v0.7.0
   - [bindW](#bindw)
   - [evalMiddleware](#evalmiddleware)
   - [execMiddleware](#execmiddleware)
+  - [iapS](#iaps)
+  - [iapSW](#iapsw)
+  - [ibind](#ibind)
+  - [ibindTo](#ibindto)
+  - [ibindW](#ibindw)
 
 ---
 
@@ -212,6 +220,50 @@ export declare const map: <A, B>(f: (a: A) => B) => <I, E>(fa: Middleware<I, I, 
 
 Added in v0.7.0
 
+# IxFunctor
+
+## imap
+
+Indexed version of [`map`](#map).
+
+**Signature**
+
+```ts
+export declare const imap: <A, B>(f: (a: A) => B) => <I, O, E>(fa: Middleware<I, O, E, A>) => Middleware<I, O, E, B>
+```
+
+Added in v0.7.0
+
+# IxMonad
+
+## ichain
+
+Indexed version of [`chain`](#chain).
+
+**Signature**
+
+```ts
+export declare const ichain: <A, O, Z, E, B>(
+  f: (a: A) => Middleware<O, Z, E, B>
+) => <I>(ma: Middleware<I, O, E, A>) => Middleware<I, Z, E, B>
+```
+
+Added in v0.7.0
+
+## ichainW
+
+Less strict version of [`ichain`](#ichain).
+
+**Signature**
+
+```ts
+export declare function ichainW<A, O, Z, E, B>(
+  f: (a: A) => Middleware<O, Z, E, B>
+): <I, D>(ma: Middleware<I, O, D, A>) => Middleware<I, Z, D | E, B>
+```
+
+Added in v0.7.0
+
 # Monad
 
 ## chain
@@ -238,32 +290,6 @@ Less strict version of [`chain`](#chain).
 export declare const chainW: <I, E2, A, B>(
   f: (a: A) => Middleware<I, I, E2, B>
 ) => <E1>(ma: Middleware<I, I, E1, A>) => Middleware<I, I, E2 | E1, B>
-```
-
-Added in v0.7.0
-
-## ichain
-
-**Signature**
-
-```ts
-export declare const ichain: <A, O, Z, E, B>(
-  f: (a: A) => Middleware<O, Z, E, B>
-) => <I>(ma: Middleware<I, O, E, A>) => Middleware<I, Z, E, B>
-```
-
-Added in v0.7.0
-
-## ichainW
-
-Less strict version of [`ichain`](#ichain).
-
-**Signature**
-
-```ts
-export declare function ichainW<A, O, Z, E, B>(
-  f: (a: A) => Middleware<O, Z, E, B>
-): <I, D>(ma: Middleware<I, O, D, A>) => Middleware<I, Z, D | E, B>
 ```
 
 Added in v0.7.0
@@ -1184,10 +1210,12 @@ Added in v0.7.0
 
 ## apSW
 
+Less strict version of [`apS`](#aps).
+
 **Signature**
 
 ```ts
-export declare const apSW: <A, N extends string, I, E2, B>(
+export declare const apSW: <N extends string, A, I, E2, B>(
   name: Exclude<N, keyof A>,
   fb: Middleware<I, I, E2, B>
 ) => <E1>(
@@ -1256,6 +1284,82 @@ export declare function execMiddleware<I, O, E, A>(
   ma: Middleware<I, O, E, A>,
   c: Connection<I>
 ): TE.TaskEither<E, Connection<O>>
+```
+
+Added in v0.7.0
+
+## iapS
+
+**Signature**
+
+```ts
+export declare const iapS: <N extends string, A, I, O, E, B>(
+  name: Exclude<N, keyof A>,
+  fb: Middleware<I, O, E, B>
+) => (fa: Middleware<I, O, E, A>) => Middleware<I, O, E, { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+```
+
+Added in v0.7.0
+
+## iapSW
+
+Less strict version of [`iapS`](#iaps).
+
+**Signature**
+
+```ts
+export declare const iapSW: <N extends string, A, I, O, E2, B>(
+  name: Exclude<N, keyof A>,
+  fb: Middleware<I, O, E2, B>
+) => <E1>(
+  fa: Middleware<I, O, E1, A>
+) => Middleware<I, O, E2 | E1, { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+```
+
+Added in v0.7.0
+
+## ibind
+
+**Signature**
+
+```ts
+export declare const ibind: <N extends string, A, O, Z, E, B>(
+  name: Exclude<N, keyof A>,
+  f: (a: A) => Middleware<O, Z, E, B>
+) => <I>(
+  ma: Middleware<I, O, E, A>
+) => Middleware<I, Z, E, { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+```
+
+Added in v0.7.0
+
+## ibindTo
+
+Indexed version of [`bindTo`](#bindto).
+
+**Signature**
+
+```ts
+export declare const ibindTo: <N extends string>(
+  name: N
+) => <I, O, E, A>(fa: Middleware<I, O, E, A>) => Middleware<I, O, E, { readonly [K in N]: A }>
+```
+
+Added in v0.7.0
+
+## ibindW
+
+Less strict version of [`ibind`](#ibind).
+
+**Signature**
+
+```ts
+export declare const ibindW: <N extends string, A, O, Z, E2, B>(
+  name: Exclude<N, keyof A>,
+  f: (a: A) => Middleware<O, Z, E2, B>
+) => <I, E1>(
+  ma: Middleware<I, O, E1, A>
+) => Middleware<I, Z, E2 | E1, { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
 ```
 
 Added in v0.7.0

--- a/docs/modules/ReaderMiddleware.ts.md
+++ b/docs/modules/ReaderMiddleware.ts.md
@@ -20,11 +20,14 @@ Added in v0.6.3
   - [mapLeft](#mapleft)
 - [Functor](#functor)
   - [map](#map)
+- [IxFunctor](#ixfunctor)
+  - [imap](#imap)
+- [IxMonad](#ixmonad)
+  - [ichain](#ichain)
+  - [ichainW](#ichainw)
 - [Monad](#monad)
   - [chain](#chain)
   - [chainW](#chainw)
-  - [ichain](#ichain)
-  - [ichainW](#ichainw)
 - [Pointed](#pointed)
   - [iof](#iof)
   - [of](#of)
@@ -120,6 +123,11 @@ Added in v0.6.3
   - [bind](#bind)
   - [bindTo](#bindto)
   - [bindW](#bindw)
+  - [iapS](#iaps)
+  - [iapSW](#iapsw)
+  - [ibind](#ibind)
+  - [ibindTo](#ibindto)
+  - [ibindW](#ibindw)
 
 ---
 
@@ -201,6 +209,52 @@ export declare const map: <A, B>(
 
 Added in v0.6.3
 
+# IxFunctor
+
+## imap
+
+Indexed version of [`map`](#map).
+
+**Signature**
+
+```ts
+export declare const imap: <A, B>(
+  f: (a: A) => B
+) => <R, I, O, E>(fa: ReaderMiddleware<R, I, O, E, A>) => ReaderMiddleware<R, I, O, E, B>
+```
+
+Added in v0.7.0
+
+# IxMonad
+
+## ichain
+
+Indexed version of [`chain`](#chain).
+
+**Signature**
+
+```ts
+export declare const ichain: <R, A, O, Z, E, B>(
+  f: (a: A) => ReaderMiddleware<R, O, Z, E, B>
+) => <I>(ma: ReaderMiddleware<R, I, O, E, A>) => ReaderMiddleware<R, I, Z, E, B>
+```
+
+Added in v0.6.3
+
+## ichainW
+
+Less strict version of [`ichain`](#ichain).
+
+**Signature**
+
+```ts
+export declare function ichainW<R2, A, O, Z, E2, B>(
+  f: (a: A) => ReaderMiddleware<R2, O, Z, E2, B>
+): <R1, I, E1>(ma: ReaderMiddleware<R1, I, O, E1, A>) => ReaderMiddleware<R1 & R2, I, Z, E1 | E2, B>
+```
+
+Added in v0.6.3
+
 # Monad
 
 ## chain
@@ -227,30 +281,6 @@ Less strict version of [`chain`](#chain).
 export declare const chainW: <R2, I, E2, A, B>(
   f: (a: A) => ReaderMiddleware<R2, I, I, E2, B>
 ) => <R1, E1>(ma: ReaderMiddleware<R1, I, I, E1, A>) => ReaderMiddleware<R1 & R2, I, I, E2 | E1, B>
-```
-
-Added in v0.6.3
-
-## ichain
-
-**Signature**
-
-```ts
-export declare const ichain: <R, A, O, Z, E, B>(
-  f: (a: A) => ReaderMiddleware<R, O, Z, E, B>
-) => <I>(ma: ReaderMiddleware<R, I, O, E, A>) => ReaderMiddleware<R, I, Z, E, B>
-```
-
-Added in v0.6.3
-
-## ichainW
-
-**Signature**
-
-```ts
-export declare function ichainW<R2, A, O, Z, E2, B>(
-  f: (a: A) => ReaderMiddleware<R2, O, Z, E2, B>
-): <R1, I, E1>(ma: ReaderMiddleware<R1, I, O, E1, A>) => ReaderMiddleware<R1 & R2, I, Z, E1 | E2, B>
 ```
 
 Added in v0.6.3
@@ -1259,10 +1289,12 @@ Added in v0.7.0
 
 ## apSW
 
+Less strict version of [`apS`](#aps).
+
 **Signature**
 
 ```ts
-export declare const apSW: <A, N extends string, I, R2, E2, B>(
+export declare const apSW: <N extends string, A, I, R2, E2, B>(
   name: Exclude<N, keyof A>,
   fb: ReaderMiddleware<R2, I, I, E2, B>
 ) => <R1, E1>(
@@ -1304,12 +1336,90 @@ Added in v0.6.3
 **Signature**
 
 ```ts
-export declare const bindW: <N extends string, R, I, A, E2, B>(
+export declare const bindW: <N extends string, R2, I, A, E2, B>(
   name: Exclude<N, keyof A>,
-  f: (a: A) => ReaderMiddleware<R, I, I, E2, B>
-) => <E1>(
-  fa: ReaderMiddleware<R, I, I, E1, A>
-) => ReaderMiddleware<R, I, I, E2 | E1, { [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+  f: (a: A) => ReaderMiddleware<R2, I, I, E2, B>
+) => <R1, E1>(
+  fa: ReaderMiddleware<R1, I, I, E1, A>
+) => ReaderMiddleware<R1 & R2, I, I, E2 | E1, { [K in N | keyof A]: K extends keyof A ? A[K] : B }>
 ```
 
 Added in v0.6.3
+
+## iapS
+
+**Signature**
+
+```ts
+export declare const iapS: <N extends string, A, R, I, O, E, B>(
+  name: Exclude<N, keyof A>,
+  fb: ReaderMiddleware<R, I, O, E, B>
+) => (
+  fa: ReaderMiddleware<R, I, O, E, A>
+) => ReaderMiddleware<R, I, O, E, { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+```
+
+Added in v0.7.0
+
+## iapSW
+
+Less strict version of [`iapS`](#iaps).
+
+**Signature**
+
+```ts
+export declare const iapSW: <N extends string, A, R2, I, O, E2, B>(
+  name: Exclude<N, keyof A>,
+  fb: ReaderMiddleware<R2, I, O, E2, B>
+) => <R1, E1>(
+  fa: ReaderMiddleware<R1, I, O, E1, A>
+) => ReaderMiddleware<R1 & R2, I, O, E2 | E1, { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+```
+
+Added in v0.7.0
+
+## ibind
+
+**Signature**
+
+```ts
+export declare const ibind: <N extends string, A, R, O, Z, E, B>(
+  name: Exclude<N, keyof A>,
+  f: (a: A) => ReaderMiddleware<R, O, Z, E, B>
+) => <I>(
+  ma: ReaderMiddleware<R, I, O, E, A>
+) => ReaderMiddleware<R, I, Z, E, { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+```
+
+Added in v0.7.0
+
+## ibindTo
+
+Indexed version of [`bindTo`](#bindto).
+
+**Signature**
+
+```ts
+export declare const ibindTo: <N extends string>(
+  name: N
+) => <R, I, O, E, A>(fa: ReaderMiddleware<R, I, O, E, A>) => ReaderMiddleware<R, I, O, E, { readonly [K in N]: A }>
+```
+
+Added in v0.7.0
+
+## ibindW
+
+Less strict version of [`ibind`](#ibind).
+
+**Signature**
+
+```ts
+export declare const ibindW: <N extends string, A, R2, O, Z, E2, B>(
+  name: Exclude<N, keyof A>,
+  f: (a: A) => ReaderMiddleware<R2, O, Z, E2, B>
+) => <R1, I, E1>(
+  ma: ReaderMiddleware<R1, I, O, E1, A>
+) => ReaderMiddleware<R1 & R2, I, Z, E2 | E1, { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+```
+
+Added in v0.7.0

--- a/src/Middleware.ts
+++ b/src/Middleware.ts
@@ -144,6 +144,21 @@ export const map =
     _map(fa, f)
 
 /**
+ * Indexed version of [`map`](#map).
+ *
+ * @category IxFunctor
+ * @since 0.7.0
+ */
+export const imap =
+  <A, B>(f: (a: A) => B) =>
+  <I, O, E>(fa: Middleware<I, O, E, A>): Middleware<I, O, E, B> =>
+  (ci) =>
+    pipe(
+      fa(ci),
+      TE.map(([a, co]) => [f(a), co])
+    )
+
+/**
  * Map a pair of functions over the two last type arguments of the bifunctor.
  *
  * @category Bifunctor
@@ -233,7 +248,7 @@ export const flatten: <I, E, A>(mma: Middleware<I, I, E, Middleware<I, I, E, A>>
 /**
  * Less strict version of [`ichain`](#ichain).
  *
- * @category Monad
+ * @category IxMonad
  * @since 0.7.0
  */
 export function ichainW<A, O, Z, E, B>(
@@ -247,7 +262,9 @@ export function ichainW<A, O, Z, E, B>(
 }
 
 /**
- * @category Monad
+ * Indexed version of [`chain`](#chain).
+ *
+ * @category IxMonad
  * @since 0.7.0
  */
 export const ichain: <A, O, Z, E, B>(
@@ -923,6 +940,15 @@ export const Do = iof<unknown, unknown, never, {}>({})
 export const bindTo = bindTo_(Functor)
 
 /**
+ * Indexed version of [`bindTo`](#bindto).
+ *
+ * @since 0.7.0
+ */
+export const ibindTo: <N extends string>(
+  name: N
+) => <I, O, E, A>(fa: Middleware<I, O, E, A>) => Middleware<I, O, E, { readonly [K in N]: A }> = bindTo as any
+
+/**
  * @since 0.7.0
  */
 export const bind = bind_(Chain)
@@ -938,16 +964,62 @@ export const bindW: <N extends string, I, A, E2, B>(
 ) => Middleware<I, I, E1 | E2, { [K in keyof A | N]: K extends keyof A ? A[K] : B }> = bind as any
 
 /**
+ * Less strict version of [`ibind`](#ibind).
+ *
+ * @since 0.7.0
+ */
+export const ibindW: <N extends string, A, O, Z, E2, B>(
+  name: Exclude<N, keyof A>,
+  f: (a: A) => Middleware<O, Z, E2, B>
+) => <I, E1>(
+  ma: Middleware<I, O, E1, A>
+) => Middleware<I, Z, E1 | E2, { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }> = bindW as any
+
+/**
+ * @since 0.7.0
+ */
+export const ibind: <N extends string, A, O, Z, E, B>(
+  name: Exclude<N, keyof A>,
+  f: (a: A) => Middleware<O, Z, E, B>
+) => <I>(
+  ma: Middleware<I, O, E, A>
+) => Middleware<I, Z, E, { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }> = ibindW
+
+/**
  * @since 0.7.0
  */
 export const apS = apS_(ApplyPar)
 
 /**
+ * Less strict version of [`apS`](#aps).
+ *
  * @since 0.7.0
  */
-export const apSW: <A, N extends string, I, E2, B>(
+export const apSW: <N extends string, A, I, E2, B>(
   name: Exclude<N, keyof A>,
   fb: Middleware<I, I, E2, B>
 ) => <E1>(
   fa: Middleware<I, I, E1, A>
 ) => Middleware<I, I, E1 | E2, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }> = apS as any
+
+/**
+ * Less strict version of [`iapS`](#iaps).
+ *
+ * @since 0.7.0
+ */
+export const iapSW: <N extends string, A, I, O, E2, B>(
+  name: Exclude<N, keyof A>,
+  fb: Middleware<I, O, E2, B>
+) => <E1>(
+  fa: Middleware<I, O, E1, A>
+) => Middleware<I, O, E1 | E2, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }> = apS as any
+
+/**
+ * @since 0.7.0
+ */
+export const iapS: <N extends string, A, I, O, E, B>(
+  name: Exclude<N, keyof A>,
+  fb: Middleware<I, O, E, B>
+) => (
+  fa: Middleware<I, O, E, A>
+) => Middleware<I, O, E, { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }> = iapSW

--- a/src/ReaderMiddleware.ts
+++ b/src/ReaderMiddleware.ts
@@ -435,6 +435,18 @@ export const map =
     _map(fa, f)
 
 /**
+ * Indexed version of [`map`](#map).
+ *
+ * @category IxFunctor
+ * @since 0.7.0
+ */
+export const imap =
+  <A, B>(f: (a: A) => B) =>
+  <R, I, O, E>(fa: ReaderMiddleware<R, I, O, E, A>): ReaderMiddleware<R, I, O, E, B> =>
+  (r) =>
+    pipe(fa(r), M.imap(f))
+
+/**
  * Map a pair of functions over the two last type arguments of the bifunctor.
  *
  * @category Bifunctor
@@ -517,7 +529,9 @@ export const chainW: <R2, I, E2, A, B>(
 ) => <R1, E1>(ma: ReaderMiddleware<R1, I, I, E1, A>) => ReaderMiddleware<R1 & R2, I, I, E1 | E2, B> = chain as any
 
 /**
- * @category Monad
+ * Indexed version of [`chain`](#chain).
+ *
+ * @category IxMonad
  * @since 0.6.3
  */
 export const ichain: <R, A, O, Z, E, B>(
@@ -525,7 +539,9 @@ export const ichain: <R, A, O, Z, E, B>(
 ) => <I>(ma: ReaderMiddleware<R, I, O, E, A>) => ReaderMiddleware<R, I, Z, E, B> = ichainW
 
 /**
- * @category Monad
+ * Less strict version of [`ichain`](#ichain).
+ *
+ * @category IxMonad
  * @since 0.6.3
  */
 export function ichainW<R2, A, O, Z, E2, B>(
@@ -922,6 +938,16 @@ export const Do = iof<unknown, unknown, unknown, never, {}>({})
 export const bindTo = bindTo_(Functor)
 
 /**
+ * Indexed version of [`bindTo`](#bindto).
+ *
+ * @since 0.7.0
+ */
+export const ibindTo: <N extends string>(
+  name: N
+) => <R, I, O, E, A>(fa: ReaderMiddleware<R, I, O, E, A>) => ReaderMiddleware<R, I, O, E, { readonly [K in N]: A }> =
+  bindTo as any
+
+/**
  * @since 0.6.3
  */
 export const bind = bind_(Chain)
@@ -929,12 +955,35 @@ export const bind = bind_(Chain)
 /**
  * @since 0.6.3
  */
-export const bindW: <N extends string, R, I, A, E2, B>(
+export const bindW: <N extends string, R2, I, A, E2, B>(
   name: Exclude<N, keyof A>,
-  f: (a: A) => ReaderMiddleware<R, I, I, E2, B>
-) => <E1>(
-  fa: ReaderMiddleware<R, I, I, E1, A>
-) => ReaderMiddleware<R, I, I, E1 | E2, { [K in keyof A | N]: K extends keyof A ? A[K] : B }> = bind as any
+  f: (a: A) => ReaderMiddleware<R2, I, I, E2, B>
+) => <R1, E1>(
+  fa: ReaderMiddleware<R1, I, I, E1, A>
+) => ReaderMiddleware<R1 & R2, I, I, E1 | E2, { [K in keyof A | N]: K extends keyof A ? A[K] : B }> = bind as any
+
+/**
+ * Less strict version of [`ibind`](#ibind).
+ *
+ * @since 0.7.0
+ */
+export const ibindW: <N extends string, A, R2, O, Z, E2, B>(
+  name: Exclude<N, keyof A>,
+  f: (a: A) => ReaderMiddleware<R2, O, Z, E2, B>
+) => <R1, I, E1>(
+  ma: ReaderMiddleware<R1, I, O, E1, A>
+) => ReaderMiddleware<R1 & R2, I, Z, E1 | E2, { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }> =
+  bindW as any
+
+/**
+ * @since 0.7.0
+ */
+export const ibind: <N extends string, A, R, O, Z, E, B>(
+  name: Exclude<N, keyof A>,
+  f: (a: A) => ReaderMiddleware<R, O, Z, E, B>
+) => <I>(
+  ma: ReaderMiddleware<R, I, O, E, A>
+) => ReaderMiddleware<R, I, Z, E, { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }> = ibindW
 
 /**
  * @since 0.7.0
@@ -942,12 +991,37 @@ export const bindW: <N extends string, R, I, A, E2, B>(
 export const apS = apS_(ApplyPar)
 
 /**
+ * Less strict version of [`apS`](#aps).
+ *
  * @since 0.7.0
  */
-export const apSW: <A, N extends string, I, R2, E2, B>(
+export const apSW: <N extends string, A, I, R2, E2, B>(
   name: Exclude<N, keyof A>,
   fb: ReaderMiddleware<R2, I, I, E2, B>
 ) => <R1, E1>(
   fa: ReaderMiddleware<R1, I, I, E1, A>
 ) => ReaderMiddleware<R1 & R2, I, I, E1 | E2, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }> =
   apS as any
+
+/**
+ * Less strict version of [`iapS`](#iaps).
+ *
+ * @since 0.7.0
+ */
+export const iapSW: <N extends string, A, R2, I, O, E2, B>(
+  name: Exclude<N, keyof A>,
+  fb: ReaderMiddleware<R2, I, O, E2, B>
+) => <R1, E1>(
+  fa: ReaderMiddleware<R1, I, O, E1, A>
+) => ReaderMiddleware<R1 & R2, I, O, E1 | E2, { readonly [K in keyof A | N]: K extends keyof A ? A[K] : B }> =
+  apS as any
+
+/**
+ * @since 0.7.0
+ */
+export const iapS: <N extends string, A, R, I, O, E, B>(
+  name: Exclude<N, keyof A>,
+  fb: ReaderMiddleware<R, I, O, E, B>
+) => (
+  fa: ReaderMiddleware<R, I, O, E, A>
+) => ReaderMiddleware<R, I, O, E, { readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }> = iapSW

--- a/test/Middleware.ts
+++ b/test/Middleware.ts
@@ -271,4 +271,23 @@ describe('Middleware', () => {
     const c = new MockConnection<H.StatusOpen>(new MockRequest())
     return assertSuccess(m, c, { a: 1, b: 'b' }, [])
   })
+
+  it('indexed do notation', () => {
+    const m = pipe(
+      _.status(H.Status.OK),
+      _.imap(() => 1),
+      _.ibindTo('a'),
+      _.ibind('b', () =>
+        pipe(
+          _.header('x-header', 'nice header'),
+          _.imap(() => 'b')
+        )
+      )
+    )
+    const c = new MockConnection<H.StatusOpen>(new MockRequest())
+    return assertSuccess(m, c, { a: 1, b: 'b' }, [
+      { type: 'setStatus', status: 200 },
+      { type: 'setHeader', name: 'x-header', value: 'nice header' },
+    ])
+  })
 })

--- a/test/ReaderMiddleware.ts
+++ b/test/ReaderMiddleware.ts
@@ -348,4 +348,32 @@ describe('ReaderMiddleware', () => {
     const c = new MockConnection<H.StatusOpen>(new MockRequest())
     return assertProperty(m1, r, m2, c)
   })
+
+  it('indexed do notation', () => {
+    const m1 = pipe(
+      _.status(H.Status.OK),
+      _.imap(() => 1),
+      _.ibindTo('a'),
+      _.ibind('b', () =>
+        pipe(
+          _.header('x-header', 'nice header'),
+          _.imap(() => 'b')
+        )
+      )
+    )
+    const r = 1
+    const m2 = pipe(
+      M.status(H.Status.OK),
+      M.imap(() => 1),
+      M.ibindTo('a'),
+      M.ibind('b', () =>
+        pipe(
+          M.header('x-header', 'nice header'),
+          M.imap(() => 'b')
+        )
+      )
+    )
+    const c = new MockConnection<H.StatusOpen>(new MockRequest())
+    return assertProperty(m1, r, m2, c)
+  })
 })


### PR DESCRIPTION
Add imap, ibindTo, ibind, ibindW, iapS, iapSW in Middleware and
ReaderMiddleware modules.
Fix type signature of apS of ReaderMiddleware, adding widening of R.

Closes https://github.com/DenisFrezzato/hyper-ts/issues/48.

