### PR TITLE
Update routing example for fp-ts-routing 0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "express": "^4.17.1",
         "fp-ts": "^2.10.0",
         "fp-ts-contrib": "^0.1.26",
-        "fp-ts-routing": "^0.4.1",
+        "fp-ts-routing": "^0.5.4",
         "husky": "^4.3.8",
         "import-path-rewrite": "github:gcanti/import-path-rewrite",
         "io-ts": "^2.0.1",
@@ -2948,28 +2948,13 @@
       }
     },
     "node_modules/fp-ts-routing": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/fp-ts-routing/-/fp-ts-routing-0.4.4.tgz",
-      "integrity": "sha512-KF/VSqtPtXlVcQg+Pb07e+P8qVYxBTkcxtQSEiApMWLOr+b5N8IFwDADJQwzFpe9Gn8WQZJy2Yr09w+Y04KEnw==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/fp-ts-routing/-/fp-ts-routing-0.5.4.tgz",
+      "integrity": "sha512-M/gWge52Kk/8RkOblFMu4k6Ddljx9JCLOsSclurra+RJDnY4i/eUT74nEHRT0X/kzn6zsKQa5rCvUmcO7L8wuw==",
       "dev": true,
-      "dependencies": {
-        "fp-ts": "^1.19.0",
-        "io-ts": "^1.10.0"
-      }
-    },
-    "node_modules/fp-ts-routing/node_modules/fp-ts": {
-      "version": "1.19.5",
-      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-1.19.5.tgz",
-      "integrity": "sha512-wDNqTimnzs8QqpldiId9OavWK2NptormjXnRJTQecNjzwfyp6P/8s/zG8e4h3ja3oqkKaY72UlTjQYt/1yXf9A==",
-      "dev": true
-    },
-    "node_modules/fp-ts-routing/node_modules/io-ts": {
-      "version": "1.10.4",
-      "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-1.10.4.tgz",
-      "integrity": "sha512-b23PteSnYXSONJ6JQXRAlvJhuw8KOtkqa87W4wDtvMrud/DTJd5X+NpOOI+O/zZwVq6v0VLAaJ+1EDViKEuN9g==",
-      "dev": true,
-      "dependencies": {
-        "fp-ts": "^1.0.0"
+      "peerDependencies": {
+        "fp-ts": "^2.0.1",
+        "io-ts": "^2.0.0"
       }
     },
     "node_modules/fragment-cache": {
@@ -12131,31 +12116,11 @@
       "requires": {}
     },
     "fp-ts-routing": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/fp-ts-routing/-/fp-ts-routing-0.4.4.tgz",
-      "integrity": "sha512-KF/VSqtPtXlVcQg+Pb07e+P8qVYxBTkcxtQSEiApMWLOr+b5N8IFwDADJQwzFpe9Gn8WQZJy2Yr09w+Y04KEnw==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/fp-ts-routing/-/fp-ts-routing-0.5.4.tgz",
+      "integrity": "sha512-M/gWge52Kk/8RkOblFMu4k6Ddljx9JCLOsSclurra+RJDnY4i/eUT74nEHRT0X/kzn6zsKQa5rCvUmcO7L8wuw==",
       "dev": true,
-      "requires": {
-        "fp-ts": "^1.19.0",
-        "io-ts": "^1.10.0"
-      },
-      "dependencies": {
-        "fp-ts": {
-          "version": "1.19.5",
-          "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-1.19.5.tgz",
-          "integrity": "sha512-wDNqTimnzs8QqpldiId9OavWK2NptormjXnRJTQecNjzwfyp6P/8s/zG8e4h3ja3oqkKaY72UlTjQYt/1yXf9A==",
-          "dev": true
-        },
-        "io-ts": {
-          "version": "1.10.4",
-          "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-1.10.4.tgz",
-          "integrity": "sha512-b23PteSnYXSONJ6JQXRAlvJhuw8KOtkqa87W4wDtvMrud/DTJd5X+NpOOI+O/zZwVq6v0VLAaJ+1EDViKEuN9g==",
-          "dev": true,
-          "requires": {
-            "fp-ts": "^1.0.0"
-          }
-        }
-      }
+      "requires": {}
     },
     "fragment-cache": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "express": "^4.17.1",
     "fp-ts": "^2.10.0",
     "fp-ts-contrib": "^0.1.26",
-    "fp-ts-routing": "^0.4.1",
+    "fp-ts-routing": "^0.5.4",
     "husky": "^4.3.8",
     "import-path-rewrite": "github:gcanti/import-path-rewrite",
     "io-ts": "^2.0.1",


### PR DESCRIPTION
The routing example uses an older version of the fp-ts-routing library, so copy/pasting doesn't work when using the latest version elsewhere. 

There's probably more I'd improve here, but this is the minimum to get it working.