### PR TITLE
Add rightReaderTask/leftReaderTask

### DIFF
--- a/docs/modules/ReaderMiddleware.ts.md
+++ b/docs/modules/ReaderMiddleware.ts.md
@@ -101,12 +101,14 @@ Added in v0.6.3
   - [left](#left)
   - [leftIO](#leftio)
   - [leftReader](#leftreader)
+  - [leftReaderTask](#leftreadertask)
   - [leftTask](#lefttask)
   - [pipeStream](#pipestream)
   - [redirect](#redirect)
   - [right](#right)
   - [rightIO](#rightio)
   - [rightReader](#rightreader)
+  - [rightReaderTask](#rightreadertask)
   - [rightTask](#righttask)
   - [send](#send)
   - [status](#status)
@@ -1162,6 +1164,18 @@ export declare function leftReader<R, I = H.StatusOpen, E = never, A = never>(
 
 Added in v0.6.3
 
+## leftReaderTask
+
+**Signature**
+
+```ts
+export declare const leftReaderTask: <R, I = H.StatusOpen, E = never, A = never>(
+  me: ReaderTask<R, E>
+) => ReaderMiddleware<R, I, I, E, A>
+```
+
+Added in v0.7.7
+
 ## leftTask
 
 **Signature**
@@ -1229,6 +1243,18 @@ export declare const rightReader: <R, I = H.StatusOpen, E = never, A = never>(
 ```
 
 Added in v0.6.3
+
+## rightReaderTask
+
+**Signature**
+
+```ts
+export declare const rightReaderTask: <R, I = H.StatusOpen, E = never, A = never>(
+  ma: ReaderTask<R, A>
+) => ReaderMiddleware<R, I, I, E, A>
+```
+
+Added in v0.7.7
 
 ## rightTask
 

--- a/dtslint/ts3.5/ReaderMiddleware.ts
+++ b/dtslint/ts3.5/ReaderMiddleware.ts
@@ -1,4 +1,5 @@
 import { pipe } from 'fp-ts/function'
+import { ReaderTask } from 'fp-ts/ReaderTask'
 import * as _ from '../../src/ReaderMiddleware'
 
 interface R1 {
@@ -13,6 +14,8 @@ declare const middleware1: _.ReaderMiddleware<R1, 'one', 'one', number, boolean>
 declare const middleware2a: _.ReaderMiddleware<R1, 'one', 'two', number, string>
 declare const middleware2b: _.ReaderMiddleware<R2, 'one', 'two', Error, string>
 declare const middleware3: _.ReaderMiddleware<R1, 'two', 'three', number, string>
+
+declare const readerTask1: ReaderTask<R1, string>
 
 //
 // ichainFirst
@@ -54,3 +57,17 @@ pipe(
   middleware1,
   _.ichainFirstW(() => middleware3) // $ExpectError
 )
+
+//
+// rightReaderTask
+//
+
+// $ExpectType ReaderMiddleware<R1, StatusOpen, StatusOpen, never, string>
+pipe(readerTask1, _.rightReaderTask)
+
+//
+// leftReaderTask
+//
+
+// $ExpectType ReaderMiddleware<R1, StatusOpen, StatusOpen, string, never>
+pipe(readerTask1, _.leftReaderTask)

--- a/src/ReaderMiddleware.ts
+++ b/src/ReaderMiddleware.ts
@@ -3,6 +3,7 @@
  */
 import { flow, identity, Lazy, pipe, Predicate, Refinement } from 'fp-ts/function'
 import { bind as bind_, chainFirst as chainFirst_, Chain4 } from 'fp-ts/Chain'
+import { ReaderTask } from 'fp-ts/ReaderTask'
 import { Task } from 'fp-ts/Task'
 import * as TE from 'fp-ts/TaskEither'
 import * as H from '.'
@@ -202,6 +203,24 @@ export function leftReader<R, I = H.StatusOpen, E = never, A = never>(
 ): ReaderMiddleware<R, I, I, E, A> {
   return (r) => M.left(me(r))
 }
+
+/**
+ * @category constructors
+ * @since 0.7.7
+ */
+export const rightReaderTask =
+  <R, I = H.StatusOpen, E = never, A = never>(ma: ReaderTask<R, A>): ReaderMiddleware<R, I, I, E, A> =>
+  (r) =>
+    M.rightTask(ma(r))
+
+/**
+ * @category constructors
+ * @since 0.7.7
+ */
+export const leftReaderTask =
+  <R, I = H.StatusOpen, E = never, A = never>(me: ReaderTask<R, E>): ReaderMiddleware<R, I, I, E, A> =>
+  (r) =>
+    M.leftTask(me(r))
 
 /**
  * @category constructors

--- a/test/ReaderMiddleware.ts
+++ b/test/ReaderMiddleware.ts
@@ -1,6 +1,7 @@
 import * as assert from 'assert'
 import * as E from 'fp-ts/Either'
 import * as TE from 'fp-ts/TaskEither'
+import * as RT from 'fp-ts/ReaderTask'
 import * as RTE from 'fp-ts/ReaderTaskEither'
 import * as t from 'io-ts'
 import * as _ from '../src/ReaderMiddleware'
@@ -46,6 +47,12 @@ function assertSuccess<R, I, O, A>(
       ),
       E.right([a, actions])
     )
+  })
+}
+
+function assertFailure<R, I, O, E>(m: _.ReaderMiddleware<R, I, O, E, any>, r: R, cin: MockConnection<I>, e: E) {
+  return m(r)(cin)().then((a) => {
+    assert.deepStrictEqual(a, E.left(e))
   })
 }
 
@@ -141,6 +148,18 @@ describe('ReaderMiddleware', () => {
     )
     const c = new MockConnection<H.StatusOpen>(new MockRequest())
     return assertSuccess(m, 4, c, 4, [])
+  })
+
+  it('rightReaderTask', async () => {
+    const m = pipe(RT.of('foo'), _.rightReaderTask)
+    const c = new MockConnection<H.StatusOpen>(new MockRequest())
+    return assertSuccess(m, 4, c, 'foo', [])
+  })
+
+  it('leftReaderTask', async () => {
+    const m = pipe(RT.of('foo'), _.leftReaderTask)
+    const c = new MockConnection<H.StatusOpen>(new MockRequest())
+    return assertFailure(m, 4, c, 'foo')
   })
 
   it('ask', () => {


### PR DESCRIPTION
Adds constructors for creating a `ReaderMiddleware` from a `ReaderTask`.