### PR TITLE
Add orElseMiddlewareK/orElseMiddlewareKW

### DIFF
--- a/docs/modules/ReaderMiddleware.ts.md
+++ b/docs/modules/ReaderMiddleware.ts.md
@@ -816,6 +816,8 @@ Added in v0.7.7
 
 ## orElseMiddlewareKW
 
+Less strict version of [`orElseMiddlewareK`](#orelsemiddlewarek).
+
 **Signature**
 
 ```ts

--- a/docs/modules/ReaderMiddleware.ts.md
+++ b/docs/modules/ReaderMiddleware.ts.md
@@ -69,6 +69,8 @@ Added in v0.6.3
   - [iflatten](#iflatten)
   - [iflattenW](#iflattenw)
   - [orElse](#orelse)
+  - [orElseMiddlewareK](#orelsemiddlewarek)
+  - [orElseMiddlewareKW](#orelsemiddlewarekw)
   - [orElseW](#orelsew)
 - [constructor](#constructor)
   - [fromConnection](#fromconnection)
@@ -799,6 +801,30 @@ export declare const orElse: <R, E, I, O, M, A>(
 ```
 
 Added in v0.6.3
+
+## orElseMiddlewareK
+
+**Signature**
+
+```ts
+export declare const orElseMiddlewareK: <E, I, O, M, A>(
+  f: (e: E) => M.Middleware<I, O, M, A>
+) => <R>(ma: ReaderMiddleware<R, I, O, E, A>) => ReaderMiddleware<R, I, O, M, A>
+```
+
+Added in v0.7.7
+
+## orElseMiddlewareKW
+
+**Signature**
+
+```ts
+export declare const orElseMiddlewareKW: <E, I, O, M, B>(
+  f: (e: E) => M.Middleware<I, O, M, B>
+) => <R, A>(ma: ReaderMiddleware<R, I, O, E, A>) => ReaderMiddleware<R, I, O, M, B | A>
+```
+
+Added in v0.7.7
 
 ## orElseW
 

--- a/dtslint/ts3.5/ReaderMiddleware.ts
+++ b/dtslint/ts3.5/ReaderMiddleware.ts
@@ -1,4 +1,5 @@
 import { pipe } from 'fp-ts/function'
+import * as M from '../../src/Middleware'
 import * as _ from '../../src/ReaderMiddleware'
 
 interface R1 {
@@ -13,6 +14,9 @@ declare const middleware1: _.ReaderMiddleware<R1, 'one', 'one', number, boolean>
 declare const middleware2a: _.ReaderMiddleware<R1, 'one', 'two', number, string>
 declare const middleware2b: _.ReaderMiddleware<R2, 'one', 'two', Error, string>
 declare const middleware3: _.ReaderMiddleware<R1, 'two', 'three', number, string>
+declare const middleware4a: M.Middleware<'one', 'one', number, boolean>
+declare const middleware4b: M.Middleware<'one', 'one', Error, string>
+declare const middleware5: M.Middleware<'one', 'two', number, string>
 
 //
 // ichainFirst
@@ -53,4 +57,45 @@ pipe(
 pipe(
   middleware1,
   _.ichainFirstW(() => middleware3) // $ExpectError
+)
+
+//
+// orElseMiddlewareK
+//
+
+// $ExpectType ReaderMiddleware<R1, "one", "one", number, boolean>
+pipe(
+  middleware1,
+  _.orElseMiddlewareK((_: number) => middleware4a)
+)
+
+pipe(
+  middleware1,
+  _.orElseMiddlewareK(() => middleware4b) // $ExpectError
+)
+
+pipe(
+  middleware1,
+  _.orElseMiddlewareK(() => middleware5) // $ExpectError
+)
+
+//
+// orElseMiddlewareKW
+//
+
+// $ExpectType ReaderMiddleware<R1, "one", "one", number, boolean>
+pipe(
+  middleware1,
+  _.orElseMiddlewareKW((_: number) => middleware4a)
+)
+
+// $ExpectType ReaderMiddleware<R1, "one", "one", Error, string | boolean>
+pipe(
+  middleware1,
+  _.orElseMiddlewareKW(() => middleware4b)
+)
+
+pipe(
+  middleware1,
+  _.orElseMiddlewareKW(() => middleware5) // $ExpectError
 )

--- a/src/ReaderMiddleware.ts
+++ b/src/ReaderMiddleware.ts
@@ -241,6 +241,8 @@ export const orElse: <R, E, I, O, M, A>(
 ) => (ma: ReaderMiddleware<R, I, O, E, A>) => ReaderMiddleware<R, I, O, M, A> = orElseW
 
 /**
+ * Less strict version of [`orElseMiddlewareK`](#orelsemiddlewarek).
+ *
  * @category combinators
  * @since 0.7.7
  */

--- a/src/ReaderMiddleware.ts
+++ b/src/ReaderMiddleware.ts
@@ -241,6 +241,28 @@ export const orElse: <R, E, I, O, M, A>(
 ) => (ma: ReaderMiddleware<R, I, O, E, A>) => ReaderMiddleware<R, I, O, M, A> = orElseW
 
 /**
+ * @category combinators
+ * @since 0.7.7
+ */
+export const orElseMiddlewareKW =
+  <E, I, O, M, B>(f: (e: E) => M.Middleware<I, O, M, B>) =>
+  <R, A>(ma: ReaderMiddleware<R, I, O, E, A>): ReaderMiddleware<R, I, O, M, A | B> =>
+  (r) =>
+  (c) =>
+    pipe(
+      ma(r)(c),
+      TE.orElseW((e) => f(e)(c))
+    )
+
+/**
+ * @category combinators
+ * @since 0.7.7
+ */
+export const orElseMiddlewareK: <E, I, O, M, A>(
+  f: (e: E) => M.Middleware<I, O, M, A>
+) => <R>(ma: ReaderMiddleware<R, I, O, E, A>) => ReaderMiddleware<R, I, O, M, A> = orElseMiddlewareKW
+
+/**
  * @category constructors
  * @since 0.6.3
  */

--- a/src/ReaderMiddleware.ts
+++ b/src/ReaderMiddleware.ts
@@ -249,12 +249,7 @@ export const orElse: <R, E, I, O, M, A>(
 export const orElseMiddlewareKW =
   <E, I, O, M, B>(f: (e: E) => M.Middleware<I, O, M, B>) =>
   <R, A>(ma: ReaderMiddleware<R, I, O, E, A>): ReaderMiddleware<R, I, O, M, A | B> =>
-  (r) =>
-  (c) =>
-    pipe(
-      ma(r)(c),
-      TE.orElseW((e) => f(e)(c))
-    )
+    flow(ma, M.orElseW(f))
 
 /**
  * @category combinators

--- a/test/ReaderMiddleware.ts
+++ b/test/ReaderMiddleware.ts
@@ -164,11 +164,11 @@ describe('ReaderMiddleware', () => {
   })
 
   it('orElseMiddlewareKW', () => {
-    const fa = _.left<unknown, H.StatusOpen, number, string>(42)
+    const fa = _.left<unknown, H.StatusOpen, number, number>(42)
     const fb = M.right('foo')
     const m = pipe(
       fa,
-      _.orElseMiddlewareK(() => fb)
+      _.orElseMiddlewareKW(() => fb)
     )
     const c = new MockConnection<H.StatusOpen>(new MockRequest())
     return assertSuccess(m, 'yee', c, 'foo', [])

--- a/test/ReaderMiddleware.ts
+++ b/test/ReaderMiddleware.ts
@@ -155,6 +155,25 @@ describe('ReaderMiddleware', () => {
     return assertSuccess(m, 'yee', c, 3, [])
   })
 
+  it('orElseMiddlewareK', () => {
+    const fa = _.left<unknown, H.StatusOpen, number, number>(42)
+    const fb = M.right
+    const m = pipe(fa, _.orElseMiddlewareK(fb))
+    const c = new MockConnection<H.StatusOpen>(new MockRequest())
+    return assertSuccess(m, 'yee', c, 42, [])
+  })
+
+  it('orElseMiddlewareKW', () => {
+    const fa = _.left<unknown, H.StatusOpen, number, string>(42)
+    const fb = M.right('foo')
+    const m = pipe(
+      fa,
+      _.orElseMiddlewareK(() => fb)
+    )
+    const c = new MockConnection<H.StatusOpen>(new MockRequest())
+    return assertSuccess(m, 'yee', c, 'foo', [])
+  })
+
   describe('status', () => {
     it('should write the status code', () => {
       const m1 = _.status(200)


### PR DESCRIPTION
Adds `orElseMiddlewareK`/`orElseMiddlewareKW` to `ReaderMiddleware`.

This avoids having to do something like `RM.orElseW(flow(someMiddleware, RM.fromMiddleware))`.