### PR TITLE
Open the index on decode middlewares

### DIFF
--- a/docs/modules/Middleware.ts.md
+++ b/docs/modules/Middleware.ts.md
@@ -812,9 +812,9 @@ Returns a middleware that tries to decode `connection.getBody()`
 **Signature**
 
 ```ts
-export declare function decodeBody<E, A>(
+export declare function decodeBody<I = StatusOpen, E = never, A = never>(
   f: (input: unknown) => E.Either<E, A>
-): Middleware<StatusOpen, StatusOpen, E, A>
+): Middleware<I, I, E, A>
 ```
 
 Added in v0.7.0
@@ -826,10 +826,10 @@ Returns a middleware that tries to decode `connection.getHeader(name)`
 **Signature**
 
 ```ts
-export declare function decodeHeader<E, A>(
+export declare function decodeHeader<I = StatusOpen, E = never, A = never>(
   name: string,
   f: (input: unknown) => E.Either<E, A>
-): Middleware<StatusOpen, StatusOpen, E, A>
+): Middleware<I, I, E, A>
 ```
 
 Added in v0.7.0
@@ -841,9 +841,9 @@ Returns a middleware that tries to decode `connection.getMethod()`
 **Signature**
 
 ```ts
-export declare function decodeMethod<E, A>(
+export declare function decodeMethod<I = StatusOpen, E = never, A = never>(
   f: (method: string) => E.Either<E, A>
-): Middleware<StatusOpen, StatusOpen, E, A>
+): Middleware<I, I, E, A>
 ```
 
 Added in v0.7.0
@@ -855,10 +855,10 @@ Returns a middleware that tries to decode `connection.getParams()[name]`
 **Signature**
 
 ```ts
-export declare function decodeParam<E, A>(
+export declare function decodeParam<I = StatusOpen, E = never, A = never>(
   name: string,
   f: (input: unknown) => E.Either<E, A>
-): Middleware<StatusOpen, StatusOpen, E, A>
+): Middleware<I, I, E, A>
 ```
 
 Added in v0.7.0
@@ -870,9 +870,9 @@ Returns a middleware that tries to decode `connection.getParams()`
 **Signature**
 
 ```ts
-export declare function decodeParams<E, A>(
+export declare function decodeParams<I = StatusOpen, E = never, A = never>(
   f: (input: unknown) => E.Either<E, A>
-): Middleware<StatusOpen, StatusOpen, E, A>
+): Middleware<I, I, E, A>
 ```
 
 Added in v0.7.0
@@ -884,9 +884,9 @@ Returns a middleware that tries to decode `connection.getQuery()`
 **Signature**
 
 ```ts
-export declare function decodeQuery<E, A>(
+export declare function decodeQuery<I = StatusOpen, E = never, A = never>(
   f: (input: unknown) => E.Either<E, A>
-): Middleware<StatusOpen, StatusOpen, E, A>
+): Middleware<I, I, E, A>
 ```
 
 Added in v0.7.0

--- a/docs/modules/ReaderMiddleware.ts.md
+++ b/docs/modules/ReaderMiddleware.ts.md
@@ -960,9 +960,9 @@ Added in v0.6.3
 **Signature**
 
 ```ts
-export declare function decodeBody<R, E, A>(
+export declare function decodeBody<R, I = H.StatusOpen, E = never, A = never>(
   f: (input: unknown) => E.Either<E, A>
-): ReaderMiddleware<R, H.StatusOpen, H.StatusOpen, E, A>
+): ReaderMiddleware<R, I, I, E, A>
 ```
 
 Added in v0.6.3
@@ -972,10 +972,10 @@ Added in v0.6.3
 **Signature**
 
 ```ts
-export declare function decodeHeader<R, E, A>(
+export declare function decodeHeader<R, I = H.StatusOpen, E = never, A = never>(
   name: string,
   f: (input: unknown) => E.Either<E, A>
-): ReaderMiddleware<R, H.StatusOpen, H.StatusOpen, E, A>
+): ReaderMiddleware<R, I, I, E, A>
 ```
 
 Added in v0.6.3
@@ -985,9 +985,9 @@ Added in v0.6.3
 **Signature**
 
 ```ts
-export declare function decodeMethod<R, E, A>(
+export declare function decodeMethod<R, I = H.StatusOpen, E = never, A = never>(
   f: (method: string) => E.Either<E, A>
-): ReaderMiddleware<R, H.StatusOpen, H.StatusOpen, E, A>
+): ReaderMiddleware<R, I, I, E, A>
 ```
 
 Added in v0.6.3
@@ -997,10 +997,10 @@ Added in v0.6.3
 **Signature**
 
 ```ts
-export declare function decodeParam<R, E, A>(
+export declare function decodeParam<R, I = H.StatusOpen, E = never, A = never>(
   name: string,
   f: (input: unknown) => E.Either<E, A>
-): ReaderMiddleware<R, H.StatusOpen, H.StatusOpen, E, A>
+): ReaderMiddleware<R, I, I, E, A>
 ```
 
 Added in v0.6.3
@@ -1010,9 +1010,9 @@ Added in v0.6.3
 **Signature**
 
 ```ts
-export declare function decodeParams<R, E, A>(
+export declare function decodeParams<R, I = H.StatusOpen, E = never, A = never>(
   f: (input: unknown) => E.Either<E, A>
-): ReaderMiddleware<R, H.StatusOpen, H.StatusOpen, E, A>
+): ReaderMiddleware<R, I, I, E, A>
 ```
 
 Added in v0.6.3
@@ -1022,9 +1022,9 @@ Added in v0.6.3
 **Signature**
 
 ```ts
-export declare function decodeQuery<R, E, A>(
+export declare function decodeQuery<R, I = H.StatusOpen, E = never, A = never>(
   f: (input: unknown) => E.Either<E, A>
-): ReaderMiddleware<R, H.StatusOpen, H.StatusOpen, E, A>
+): ReaderMiddleware<R, I, I, E, A>
 ```
 
 Added in v0.6.3

--- a/dtslint/ts3.5/Middleware.ts
+++ b/dtslint/ts3.5/Middleware.ts
@@ -1,3 +1,4 @@
+import * as E from 'fp-ts/Either'
 import { pipe } from 'fp-ts/function'
 import * as _ from '../../src/Middleware'
 
@@ -5,6 +6,62 @@ declare const middleware1: _.Middleware<'one', 'one', number, boolean>
 declare const middleware2a: _.Middleware<'one', 'two', number, string>
 declare const middleware2b: _.Middleware<'one', 'two', Error, string>
 declare const middleware3: _.Middleware<'two', 'three', number, string>
+declare const decoderU: (value: unknown) => E.Either<number, boolean>
+declare const decoderS: (value: string) => E.Either<number, boolean>
+
+//
+// decodeParam
+//
+
+// $ExpectType Middleware<StatusOpen, StatusOpen, number, boolean>
+_.decodeParam('foo', decoderU)
+// $ExpectType Middleware<"one", "one", number, boolean>
+_.decodeParam<'one', number, boolean>('foo', decoderU)
+
+//
+// decodeParams
+//
+
+// $ExpectType Middleware<StatusOpen, StatusOpen, number, boolean>
+_.decodeParams(decoderU)
+// $ExpectType Middleware<"one", "one", number, boolean>
+_.decodeParams<'one', number, boolean>(decoderU)
+
+//
+// decodeQuery
+//
+
+// $ExpectType Middleware<StatusOpen, StatusOpen, number, boolean>
+_.decodeQuery(decoderU)
+// $ExpectType Middleware<"one", "one", number, boolean>
+_.decodeQuery<'one', number, boolean>(decoderU)
+
+//
+// decodeBody
+//
+
+// $ExpectType Middleware<StatusOpen, StatusOpen, number, boolean>
+_.decodeBody(decoderU)
+// $ExpectType Middleware<"one", "one", number, boolean>
+_.decodeBody<'one', number, boolean>(decoderU)
+
+//
+// decodeMethod
+//
+
+// $ExpectType Middleware<StatusOpen, StatusOpen, number, boolean>
+_.decodeMethod(decoderS)
+// $ExpectType Middleware<"one", "one", number, boolean>
+_.decodeMethod<'one', number, boolean>(decoderS)
+
+//
+// decodeHeader
+//
+
+// $ExpectType Middleware<StatusOpen, StatusOpen, number, boolean>
+_.decodeHeader('foo', decoderU)
+// $ExpectType Middleware<"one", "one", number, boolean>
+_.decodeHeader<'one', number, boolean>('foo', decoderU)
 
 //
 // ichainFirst

--- a/dtslint/ts3.5/ReaderMiddleware.ts
+++ b/dtslint/ts3.5/ReaderMiddleware.ts
@@ -1,3 +1,4 @@
+import * as E from 'fp-ts/Either'
 import { pipe } from 'fp-ts/function'
 import { ReaderTask } from 'fp-ts/ReaderTask'
 import * as M from '../../src/Middleware'
@@ -20,6 +21,62 @@ declare const middleware4b: M.Middleware<'one', 'one', Error, string>
 declare const middleware5: M.Middleware<'one', 'two', number, string>
 
 declare const readerTask1: ReaderTask<R1, string>
+declare const decoderU: (value: unknown) => E.Either<number, boolean>
+declare const decoderS: (value: string) => E.Either<number, boolean>
+
+//
+// decodeParam
+//
+
+// $ExpectType ReaderMiddleware<unknown, StatusOpen, StatusOpen, number, boolean>
+_.decodeParam('foo', decoderU)
+// $ExpectType ReaderMiddleware<R1, "one", "one", number, boolean>
+_.decodeParam<R1, 'one', number, boolean>('foo', decoderU)
+
+//
+// decodeParams
+//
+
+// $ExpectType ReaderMiddleware<unknown, StatusOpen, StatusOpen, number, boolean>
+_.decodeParams(decoderU)
+// $ExpectType ReaderMiddleware<R1, "one", "one", number, boolean>
+_.decodeParams<R1, 'one', number, boolean>(decoderU)
+
+//
+// decodeQuery
+//
+
+// $ExpectType ReaderMiddleware<unknown, StatusOpen, StatusOpen, number, boolean>
+_.decodeQuery(decoderU)
+// $ExpectType ReaderMiddleware<R1, "one", "one", number, boolean>
+_.decodeQuery<R1, 'one', number, boolean>(decoderU)
+
+//
+// decodeBody
+//
+
+// $ExpectType ReaderMiddleware<unknown, StatusOpen, StatusOpen, number, boolean>
+_.decodeBody(decoderU)
+// $ExpectType ReaderMiddleware<R1, "one", "one", number, boolean>
+_.decodeBody<R1, 'one', number, boolean>(decoderU)
+
+//
+// decodeMethod
+//
+
+// $ExpectType ReaderMiddleware<unknown, StatusOpen, StatusOpen, number, boolean>
+_.decodeMethod(decoderS)
+// $ExpectType ReaderMiddleware<R1, "one", "one", number, boolean>
+_.decodeMethod<R1, 'one', number, boolean>(decoderS)
+
+//
+// decodeHeader
+//
+
+// $ExpectType ReaderMiddleware<unknown, StatusOpen, StatusOpen, number, boolean>
+_.decodeHeader('foo', decoderU)
+// $ExpectType ReaderMiddleware<R1, "one", "one", number, boolean>
+_.decodeHeader<R1, 'one', number, boolean>('foo', decoderU)
 
 //
 // ichainFirst

--- a/src/Middleware.ts
+++ b/src/Middleware.ts
@@ -625,10 +625,10 @@ const isUnknownRecord = (u: unknown): u is Record<string, unknown> => u !== null
  * @category constructors
  * @since 0.7.0
  */
-export function decodeParam<E, A>(
+export function decodeParam<I = StatusOpen, E = never, A = never>(
   name: string,
   f: (input: unknown) => E.Either<E, A>
-): Middleware<StatusOpen, StatusOpen, E, A> {
+): Middleware<I, I, E, A> {
   return fromConnection((c) => {
     const params = c.getParams()
     return f(isUnknownRecord(params) ? params[name] : undefined)
@@ -641,7 +641,9 @@ export function decodeParam<E, A>(
  * @category constructors
  * @since 0.7.0
  */
-export function decodeParams<E, A>(f: (input: unknown) => E.Either<E, A>): Middleware<StatusOpen, StatusOpen, E, A> {
+export function decodeParams<I = StatusOpen, E = never, A = never>(
+  f: (input: unknown) => E.Either<E, A>
+): Middleware<I, I, E, A> {
   return fromConnection((c) => f(c.getParams()))
 }
 
@@ -651,7 +653,9 @@ export function decodeParams<E, A>(f: (input: unknown) => E.Either<E, A>): Middl
  * @category constructors
  * @since 0.7.0
  */
-export function decodeQuery<E, A>(f: (input: unknown) => E.Either<E, A>): Middleware<StatusOpen, StatusOpen, E, A> {
+export function decodeQuery<I = StatusOpen, E = never, A = never>(
+  f: (input: unknown) => E.Either<E, A>
+): Middleware<I, I, E, A> {
   return fromConnection((c) => f(c.getQuery()))
 }
 
@@ -661,7 +665,9 @@ export function decodeQuery<E, A>(f: (input: unknown) => E.Either<E, A>): Middle
  * @category constructors
  * @since 0.7.0
  */
-export function decodeBody<E, A>(f: (input: unknown) => E.Either<E, A>): Middleware<StatusOpen, StatusOpen, E, A> {
+export function decodeBody<I = StatusOpen, E = never, A = never>(
+  f: (input: unknown) => E.Either<E, A>
+): Middleware<I, I, E, A> {
   return fromConnection((c) => f(c.getBody()))
 }
 
@@ -671,7 +677,9 @@ export function decodeBody<E, A>(f: (input: unknown) => E.Either<E, A>): Middlew
  * @category constructors
  * @since 0.7.0
  */
-export function decodeMethod<E, A>(f: (method: string) => E.Either<E, A>): Middleware<StatusOpen, StatusOpen, E, A> {
+export function decodeMethod<I = StatusOpen, E = never, A = never>(
+  f: (method: string) => E.Either<E, A>
+): Middleware<I, I, E, A> {
   return fromConnection((c) => f(c.getMethod()))
 }
 
@@ -681,10 +689,10 @@ export function decodeMethod<E, A>(f: (method: string) => E.Either<E, A>): Middl
  * @category constructors
  * @since 0.7.0
  */
-export function decodeHeader<E, A>(
+export function decodeHeader<I = StatusOpen, E = never, A = never>(
   name: string,
   f: (input: unknown) => E.Either<E, A>
-): Middleware<StatusOpen, StatusOpen, E, A> {
+): Middleware<I, I, E, A> {
   return fromConnection((c) => f(c.getHeader(name)))
 }
 

--- a/src/ReaderMiddleware.ts
+++ b/src/ReaderMiddleware.ts
@@ -391,10 +391,10 @@ export function pipeStream<R, E>(
  * @category constructors
  * @since 0.6.3
  */
-export function decodeParam<R, E, A>(
+export function decodeParam<R, I = H.StatusOpen, E = never, A = never>(
   name: string,
   f: (input: unknown) => E.Either<E, A>
-): ReaderMiddleware<R, H.StatusOpen, H.StatusOpen, E, A> {
+): ReaderMiddleware<R, I, I, E, A> {
   return () => M.decodeParam(name, f)
 }
 
@@ -402,9 +402,9 @@ export function decodeParam<R, E, A>(
  * @category constructors
  * @since 0.6.3
  */
-export function decodeParams<R, E, A>(
+export function decodeParams<R, I = H.StatusOpen, E = never, A = never>(
   f: (input: unknown) => E.Either<E, A>
-): ReaderMiddleware<R, H.StatusOpen, H.StatusOpen, E, A> {
+): ReaderMiddleware<R, I, I, E, A> {
   return () => M.decodeParams(f)
 }
 
@@ -412,9 +412,9 @@ export function decodeParams<R, E, A>(
  * @category constructors
  * @since 0.6.3
  */
-export function decodeQuery<R, E, A>(
+export function decodeQuery<R, I = H.StatusOpen, E = never, A = never>(
   f: (input: unknown) => E.Either<E, A>
-): ReaderMiddleware<R, H.StatusOpen, H.StatusOpen, E, A> {
+): ReaderMiddleware<R, I, I, E, A> {
   return () => M.decodeQuery(f)
 }
 
@@ -422,9 +422,9 @@ export function decodeQuery<R, E, A>(
  * @category constructors
  * @since 0.6.3
  */
-export function decodeBody<R, E, A>(
+export function decodeBody<R, I = H.StatusOpen, E = never, A = never>(
   f: (input: unknown) => E.Either<E, A>
-): ReaderMiddleware<R, H.StatusOpen, H.StatusOpen, E, A> {
+): ReaderMiddleware<R, I, I, E, A> {
   return () => M.decodeBody(f)
 }
 
@@ -432,9 +432,9 @@ export function decodeBody<R, E, A>(
  * @category constructors
  * @since 0.6.3
  */
-export function decodeMethod<R, E, A>(
+export function decodeMethod<R, I = H.StatusOpen, E = never, A = never>(
   f: (method: string) => E.Either<E, A>
-): ReaderMiddleware<R, H.StatusOpen, H.StatusOpen, E, A> {
+): ReaderMiddleware<R, I, I, E, A> {
   return () => M.decodeMethod(f)
 }
 
@@ -442,10 +442,10 @@ export function decodeMethod<R, E, A>(
  * @category constructors
  * @since 0.6.3
  */
-export function decodeHeader<R, E, A>(
+export function decodeHeader<R, I = H.StatusOpen, E = never, A = never>(
   name: string,
   f: (input: unknown) => E.Either<E, A>
-): ReaderMiddleware<R, H.StatusOpen, H.StatusOpen, E, A> {
+): ReaderMiddleware<R, I, I, E, A> {
   return () => M.decodeHeader(name, f)
 }
 const _map: Functor4<URI>['map'] = (fa, f) => (r) => pipe(fa(r), M.map(f))


### PR DESCRIPTION
The `decodeX` middleware use `fromConnection` but restrict the index to `StatusOpen`. I can't see a reason for it, so this PR makes `I` a generic on these functions.