### PR TITLE
Allow redirect to take a URL

### DIFF
--- a/docs/modules/Middleware.ts.md
+++ b/docs/modules/Middleware.ts.md
@@ -1054,7 +1054,9 @@ Returns a middleware that sends a redirect to `uri`
 **Signature**
 
 ```ts
-export declare function redirect<E = never>(uri: string): Middleware<StatusOpen, HeadersOpen, E, void>
+export declare function redirect<E = never>(
+  uri: string | { href: string }
+): Middleware<StatusOpen, HeadersOpen, E, void>
 ```
 
 Added in v0.7.0

--- a/docs/modules/ReaderMiddleware.ts.md
+++ b/docs/modules/ReaderMiddleware.ts.md
@@ -1235,7 +1235,9 @@ Added in v0.7.3
 **Signature**
 
 ```ts
-export declare function redirect<R, E = never>(uri: string): ReaderMiddleware<R, H.StatusOpen, H.HeadersOpen, E, void>
+export declare function redirect<R, E = never>(
+  uri: string | { href: string }
+): ReaderMiddleware<R, H.StatusOpen, H.HeadersOpen, E, void>
 ```
 
 Added in v0.6.3

--- a/src/Middleware.ts
+++ b/src/Middleware.ts
@@ -600,10 +600,10 @@ export function json<E>(
  * @category constructors
  * @since 0.7.0
  */
-export function redirect<E = never>(uri: string): Middleware<StatusOpen, HeadersOpen, E, void> {
+export function redirect<E = never>(uri: string | { href: string }): Middleware<StatusOpen, HeadersOpen, E, void> {
   return pipe(
     status(Status.Found),
-    ichain(() => header('Location', uri))
+    ichain(() => header('Location', typeof uri === 'string' ? uri : uri.href))
   )
 }
 

--- a/src/ReaderMiddleware.ts
+++ b/src/ReaderMiddleware.ts
@@ -371,7 +371,9 @@ export function json<R, E>(
  * @category constructors
  * @since 0.6.3
  */
-export function redirect<R, E = never>(uri: string): ReaderMiddleware<R, H.StatusOpen, H.HeadersOpen, E, void> {
+export function redirect<R, E = never>(
+  uri: string | { href: string }
+): ReaderMiddleware<R, H.StatusOpen, H.HeadersOpen, E, void> {
   return () => M.redirect(uri)
 }
 

--- a/test/Middleware.ts
+++ b/test/Middleware.ts
@@ -174,12 +174,15 @@ describe('Middleware', () => {
   })
 
   describe('redirect', () => {
-    it('should add the correct status / header', () => {
-      const m = _.redirect('/users')
+    it.each([
+      ['string', '/users', '/users'],
+      ['URL', new URL('http://example.com/users'), 'http://example.com/users'],
+    ])('should add the correct status / header for a %s', (_type, actual, expected) => {
+      const m = _.redirect(actual)
       const c = new MockConnection<H.StatusOpen>(new MockRequest())
       return assertSuccess(m, c, undefined, [
         { type: 'setStatus', status: 302 },
-        { type: 'setHeader', name: 'Location', value: '/users' },
+        { type: 'setHeader', name: 'Location', value: expected },
       ])
     })
   })

--- a/test/ReaderMiddleware.ts
+++ b/test/ReaderMiddleware.ts
@@ -270,10 +270,13 @@ describe('ReaderMiddleware', () => {
   })
 
   describe('redirect', () => {
-    it('should add the correct status / header', () => {
-      const m1 = _.redirect('/users')
+    it.each([
+      ['string', '/users', '/users'],
+      ['URL', new URL('http://example.com/users'), 'http://example.com/users'],
+    ])('should add the correct status / header for a %s', (_type, actual, expected) => {
+      const m1 = _.redirect(actual)
       const r = 'yee'
-      const m2 = M.redirect('/users')
+      const m2 = M.redirect(expected)
       const c = new MockConnection<H.StatusOpen>(new MockRequest())
       return assertProperty(m1, r, m2, c)
     })


### PR DESCRIPTION
Allows the input to `redirect` to be a `URL`-like object, as well as a `string`.