### PR TITLE
`pipeStream`: use `never` as default for type parameter `E`

### DIFF
--- a/src/ReaderMiddleware.ts
+++ b/src/ReaderMiddleware.ts
@@ -525,7 +525,7 @@ export function redirect<R, E = never>(
  * @category constructors
  * @since 0.7.3
  */
-export function pipeStream<R, E>(
+export function pipeStream<R, E = never>(
   stream: NodeJS.ReadableStream,
   onError: (reason: unknown) => ReaderIO<R, void>
 ): ReaderMiddleware<R, H.BodyOpen, H.ResponseEnded, E, void> {


### PR DESCRIPTION
This fixes the following type error:

```ts
import * as H from 'hyper-ts';
import * as HRM from 'hyper-ts/ReaderMiddleware';

import { pipe } from 'shared/facades/function';

type Deps = {};

declare const stream: NodeJS.ReadableStream;
declare const onError: (reason: unknown) => ReaderIO<Deps, void>;

declare const a: HRM.ReaderMiddleware<
  Deps,
  H.StatusOpen,
  H.BodyOpen,
  number,
  void
>;

// Type 'ReaderMiddleware<Deps, StatusOpen, ResponseEnded, unknown, void>' is not assignable to type 'ReaderMiddleware<Deps, StatusOpen, ResponseEnded, number, void>'.
//   Type 'unknown' is not assignable to type 'number'.
const b: HRM.ReaderMiddleware<
  Deps,
  H.StatusOpen,
  H.ResponseEnded,
  number,
  void
> = pipe(
  a,
  HRM.ichainW(() => HRM.pipeStream(stream, onError)),
);
```

/cc @mlegenhausen 